### PR TITLE
docs: update CHANGELOG release date to 2025-11-20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.1] - 2025-11-19
+## [0.0.1] - 2025-11-20
 
 ### Added
 


### PR DESCRIPTION
## Summary
- Updated the 0.0.1 release date in CHANGELOG.md to reflect the actual GitHub release date (2025-11-20)

## Test plan
- [x] Verified CHANGELOG.md format is correct
- [x] Date matches the actual GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)