### PR TITLE
Fix CodeQL unused bindings

### DIFF
--- a/examples/sdk-usage.ts
+++ b/examples/sdk-usage.ts
@@ -63,7 +63,8 @@ async function directUsageExample() {
 // =====================================================
 
 // import OpenAI from 'openai';
-import { openAITools, processToolCalls } from '../src/sdk/adapters/openai.js';
+// import { processToolCalls } from '../src/sdk/adapters/openai.js';
+import { openAITools } from '../src/sdk/adapters/openai.js';
 
 async function openAIExample() {
   // Uncomment when using with actual OpenAI SDK

--- a/test-e2e.js
+++ b/test-e2e.js
@@ -194,7 +194,7 @@ async function testSearchRepertory() {
   // Test 3: Validation - symptom too short
   try {
     logInfo('Test 3: Validation test (symptom too short)');
-    const result = await callToolOrThrow({
+    await callToolOrThrow({
       name: 'search_repertory',
       arguments: {
         symptom: 'ab', // Too short


### PR DESCRIPTION
## Summary

Remove the two unused bindings reported by CodeQL without changing the executed calls or example behavior.

## Motivation

CodeQL alerts [#1](https://github.com/Dhi13man/oorep-mcp/security/code-scanning/1) and [#2](https://github.com/Dhi13man/oorep-mcp/security/code-scanning/2) identify a discarded validation result and an import used only by commented example code. Removing those active bindings clears avoidable static-analysis noise while preserving both examples.

## Changes

- Await the expected validation failure directly in `test-e2e.js`.
- Keep `processToolCalls` as a commented opt-in import beside the commented OpenAI example while retaining the active `openAITools` import.

## Testing

- TypeScript typecheck, ESLint, build, direct example compilation, and JavaScript syntax check: passed.
- Vitest: 37 files and all 1,102 tests passed.
- Coverage: 94.81% statements, 93.65% branches, 94.92% functions, and 94.94% lines.
- Live MCP e2e: candidate reached 29/35; the exact parent reached 26/34. Both failed only on unstable upstream timeout/fetch paths, so this is not recorded as a passing gate.
- Gitleaks 8.30.1: no findings across 140 commits.
- Package dry run: 96.0 kB and 175 files.
- `git diff --check`: passed.

Direct Prettier checks fail on both changed files at the parent and candidate due existing file-wide formatting drift; every touched line matches Prettier output. Exact-head CodeQL must confirm both alerts close before merge.

## Screenshots

Not applicable; no user interface changed.

## Checklist

- [x] Tests updated: the existing validation path retains the same awaited call and error assertion.
- [x] Documentation updated: the commented example import remains usable when the example is enabled.
- [x] CHANGELOG updated: not applicable; public and runtime behavior are unchanged.
- [ ] All exact-head CI checks pass.
