### PR TITLE
ci: scope CodeQL write permission

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,12 +11,15 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze with CodeQL
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Why

OOREP's CodeQL workflow granted `security-events: write` at the workflow level. Only the analysis job uploads SARIF, so the write permission should be scoped to that job.

## What changed

- keep the workflow-level token read-only
- grant CodeQL's analysis job only the read and SARIF-upload permissions it uses

## Test plan

- [x] actionlint
- [x] parse workflow YAML
- [x] de-bloat register scan (0 findings)
- [x] Gitleaks across repository history (0 leaks)
- [x] `git diff --check`
- [ ] exact-head CodeQL and CI

## How to review

1. Confirm no workflow trigger or step changed.
2. Confirm the analysis job retains `security-events: write` for SARIF upload.
3. Confirm all other jobs inherit read-only permissions.
