### PR TITLE
chore(release): publish v1.2.2

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+custom:
+  - https://www.buymeacoffee.com/dhi13man

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,47 +55,6 @@ jobs:
         if: matrix.node-version == '22.x'
         run: npm run test:coverage
 
-      - name: Store coverage report
-        if: matrix.node-version == '22.x'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-${{ github.run_id }}
-          path: coverage/lcov.info
-          if-no-files-found: error
-          retention-days: 1
-
-  coverage-upload:
-    name: Upload coverage
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-        with:
-          persist-credentials: false
-          submodules: false
-
-      - name: Download coverage
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: coverage-${{ github.run_id }}
-          path: coverage
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
-        with:
-          use_oidc: true
-          version: v11.3.1
-          files: ./coverage/lcov.info
-          disable_search: true
-          fail_ci_if_error: true
-          verbose: true
-
   build-verification:
     name: Build Verification
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,14 @@ on:
   pull_request:
     branches: [main, master]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   test:
     name: Test on Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -54,17 +55,52 @@ jobs:
         if: matrix.node-version == '22.x'
         run: npm run test:coverage
 
-      - name: Upload coverage to Codecov
+      - name: Store coverage report
         if: matrix.node-version == '22.x'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-${{ github.run_id }}
+          path: coverage/lcov.info
+          if-no-files-found: error
+          retention-days: 1
+
+  coverage-upload:
+    name: Upload coverage
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+          submodules: false
+
+      - name: Download coverage
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-${{ github.run_id }}
+          path: coverage
+
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+          use_oidc: true
+          version: v11.3.1
+          files: ./coverage/lcov.info
+          disable_search: true
+          fail_ci_if_error: true
           verbose: true
 
   build-verification:
     name: Build Verification
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,21 +3,21 @@ name: Publish to npm
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag to publish (e.g., v1.0.0)'
-        required: true
-        type: string
 
-permissions:
-  contents: read
-  id-token: write  # Required for npm provenance
+permissions: {}
+
+concurrency:
+  group: publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
 
 jobs:
   publish:
-    name: Publish to npm
+    name: Publish release
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -25,46 +25,198 @@ jobs:
         with:
           persist-credentials: false
           submodules: false
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Verify release commit is protected
+        run: |
+          git fetch --no-tags --depth=1 origin master
+          RELEASE_COMMIT=$(git rev-parse HEAD)
+          PROTECTED_COMMIT=$(git rev-parse origin/master)
+
+          if [ "$RELEASE_COMMIT" != "$PROTECTED_COMMIT" ]; then
+            echo "Release tag must point to the current protected master commit"
+            echo "Release commit: $RELEASE_COMMIT"
+            echo "Protected commit: $PROTECTED_COMMIT"
+            exit 1
+          fi
+          echo "Release commit is the current protected master commit: $RELEASE_COMMIT"
 
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
-          cache: 'npm'
+          package-manager-cache: false
 
       - name: Verify version matches tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          TAG_VERSION=${{ github.event.release.tag_name || inputs.tag }}
-          TAG_VERSION=${TAG_VERSION#v}  # Remove 'v' prefix if present
+          TAG_VERSION=${RELEASE_TAG#v}
+          SERVER_VERSION=$(node -p "require('./server.json').version")
+          SERVER_PACKAGE_VERSION=$(node -p "require('./server.json').packages[0].version")
 
           if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
-            echo "❌ Version mismatch: package.json=$PACKAGE_VERSION, tag=$TAG_VERSION"
+            echo "Version mismatch: package.json=$PACKAGE_VERSION, tag=$TAG_VERSION"
             exit 1
           fi
-          echo "✓ Version matches: $PACKAGE_VERSION"
+          if [ "$SERVER_VERSION" != "$PACKAGE_VERSION" ] || [ "$SERVER_PACKAGE_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Version mismatch: package.json=$PACKAGE_VERSION, server.json=$SERVER_VERSION, server package=$SERVER_PACKAGE_VERSION"
+            exit 1
+          fi
+          echo "Version matches: $PACKAGE_VERSION"
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm test
+      - name: Verify package
+        run: npm run prepublishOnly
 
-      - name: Build
-        run: npm run build
+      - name: Pack and publish to npm
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          PACK_RESULT=$(npm pack --json)
+          PACKAGE_TARBALL=$(node -e "const [result] = JSON.parse(process.argv[1]); process.stdout.write(result.filename)" "$PACK_RESULT")
+          LOCAL_INTEGRITY=$(node -e "const [result] = JSON.parse(process.argv[1]); process.stdout.write(result.integrity)" "$PACK_RESULT")
 
-      - name: Publish to npm with provenance
-        run: npm publish --provenance --access public
+          if npm view "oorep-mcp@$PACKAGE_VERSION" version >/dev/null 2>&1; then
+            PUBLISHED_DIST=$(npm view "oorep-mcp@$PACKAGE_VERSION" dist --json)
+            PUBLISHED_INTEGRITY=$(node -e "process.stdout.write(JSON.parse(process.argv[1]).integrity ?? '')" "$PUBLISHED_DIST")
+            if [ "$PUBLISHED_INTEGRITY" != "$LOCAL_INTEGRITY" ]; then
+              echo "oorep-mcp@$PACKAGE_VERSION exists with different package contents"
+              exit 1
+            fi
+            if ! node -e '
+              const dist = JSON.parse(process.argv[1]);
+              const predicate = dist.attestations?.provenance?.predicateType;
+              process.exit(predicate === "https://slsa.dev/provenance/v1" ? 0 : 1);
+            ' "$PUBLISHED_DIST"
+            then
+              echo "oorep-mcp@$PACKAGE_VERSION exists without the expected provenance attestation"
+              exit 1
+            fi
+            echo "oorep-mcp@$PACKAGE_VERSION is already published with matching integrity and provenance"
+          else
+            npm publish "$PACKAGE_TARBALL" --access public
+          fi
+
+      - name: Wait for npm registry propagation
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          for attempt in {1..12}; do
+            if [ "$(npm view "oorep-mcp@$PACKAGE_VERSION" version 2>/dev/null)" = "$PACKAGE_VERSION" ]; then
+              echo "oorep-mcp@$PACKAGE_VERSION is available on npm"
+              exit 0
+            fi
+            echo "Waiting for npm registry propagation ($attempt/12)"
+            sleep 10
+          done
+          echo "oorep-mcp@$PACKAGE_VERSION did not become available on npm"
+          exit 1
+
+      - name: Verify npm provenance
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          PROVENANCE_AVAILABLE=false
+
+          for attempt in {1..12}; do
+            PUBLISHED_DIST=$(npm view "oorep-mcp@$PACKAGE_VERSION" dist --json)
+            if node -e '
+              const dist = JSON.parse(process.argv[1]);
+              const predicate = dist.attestations?.provenance?.predicateType;
+              process.exit(predicate === "https://slsa.dev/provenance/v1" ? 0 : 1);
+            ' "$PUBLISHED_DIST"
+            then
+              PROVENANCE_AVAILABLE=true
+              break
+            fi
+            echo "Waiting for npm provenance propagation ($attempt/12)"
+            sleep 10
+          done
+
+          if [ "$PROVENANCE_AVAILABLE" != true ]; then
+            echo "oorep-mcp@$PACKAGE_VERSION is missing its provenance attestation"
+            exit 1
+          fi
+
+          PROVENANCE_CHECK_DIR=$(mktemp --directory)
+          npm install --prefix "$PROVENANCE_CHECK_DIR" --ignore-scripts --prefer-online "oorep-mcp@$PACKAGE_VERSION"
+          npm --prefix "$PROVENANCE_CHECK_DIR" audit signatures
+
+      - name: Install MCP Registry publisher
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          MCP_PUBLISHER_VERSION: v1.8.0
+          MCP_PUBLISHER_SHA256: 1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf
+        run: |
+          curl --fail --location --silent --show-error \
+            --output mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "$MCP_PUBLISHER_SHA256  mcp-publisher.tar.gz" | sha256sum --check
+          tar --extract --gzip --file mcp-publisher.tar.gz mcp-publisher
+          ./mcp-publisher --help >/dev/null
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: |
+          SERVER_NAME=$(node -p "require('./server.json').name")
+          SERVER_VERSION=$(node -p "require('./server.json').version")
+          ENCODED_SERVER_NAME=$(node -p "encodeURIComponent(require('./server.json').name)")
+          ENCODED_SERVER_VERSION=$(node -p "encodeURIComponent(require('./server.json').version)")
+          REGISTRY_RESPONSE_FILE=$(mktemp)
+          REGISTRY_HTTP_STATUS=$(curl --silent --show-error \
+            --output "$REGISTRY_RESPONSE_FILE" \
+            --write-out "%{http_code}" \
+            "https://registry.modelcontextprotocol.io/v0.1/servers/$ENCODED_SERVER_NAME/versions/$ENCODED_SERVER_VERSION")
+
+          case "$REGISTRY_HTTP_STATUS" in
+            200)
+              REGISTRY_RESPONSE=$(<"$REGISTRY_RESPONSE_FILE")
+              REGISTRY_STATUS=$(
+                REGISTRY_RESPONSE="$REGISTRY_RESPONSE" node -e '
+                  const response = JSON.parse(process.env.REGISTRY_RESPONSE);
+                  const local = require("./server.json");
+                  const published = response.server;
+
+                  const fields = ["name", "version", "description", "repository", "packages", "remotes"];
+                  const stable = (value) => {
+                    if (Array.isArray(value)) return value.map(stable);
+                    if (value && typeof value === "object") {
+                      return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stable(value[key])]));
+                    }
+                    return value ?? null;
+                  };
+                  const select = (server) => Object.fromEntries(fields.map((field) => [field, stable(server[field])]));
+                  process.stdout.write(JSON.stringify(select(local)) === JSON.stringify(select(published)) ? "matching" : "mismatch");
+                '
+              )
+              if [ "$REGISTRY_STATUS" != matching ]; then
+                echo "$SERVER_NAME@$SERVER_VERSION exists with different registry metadata"
+                exit 1
+              fi
+              echo "$SERVER_NAME@$SERVER_VERSION is already published with matching metadata"
+              ;;
+            404)
+              ./mcp-publisher publish
+              ;;
+            *)
+              echo "MCP Registry lookup failed with HTTP $REGISTRY_HTTP_STATUS"
+              exit 1
+              ;;
+          esac
 
       - name: Create publication summary
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          echo "### 📦 Published to npm" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Package**: oorep-mcp" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version**: $(node -p 'require(\"./package.json\").version')" >> $GITHUB_STEP_SUMMARY
-          echo "- **Tag**: ${{ github.event.release.tag_name || inputs.tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Provenance**: ✓ Enabled" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### Release published"
+            echo ""
+            echo "- **Package**: oorep-mcp"
+            echo "- **Version**: $(node -p 'require(\"./package.json\").version')"
+            echo "- **Tag**: $RELEASE_TAG"
+            echo "- **npm provenance**: enabled by trusted publishing"
+            echo "- **MCP Registry**: io.github.dhi13man/oorep-mcp"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
+      - name: Install trusted publishing npm
+        run: npm install --global npm@11.6.1
+
       - name: Verify version matches tag
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "oorep"]
 	path = oorep
-	url = git@github.com:nondeterministic/oorep.git
+	url = https://github.com/nondeterministic/oorep.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-08-03
+
+### Added
+
+- **Open-source maintenance**: Added community issue and pull request templates,
+  a Code of Conduct, private vulnerability-reporting guidance, and OpenSSF
+  Scorecard reporting.
+- **MCP Registry publishing**: Added current registry metadata and automated
+  publication of `io.github.dhi13man/oorep-mcp` after npm releases.
+- **Project metadata**: Added citation metadata, GitHub funding configuration,
+  and provenance context for the repertory structure analysis.
+
+### Changed
+
+- **Supported runtime**: Raised the minimum Node.js version from 18 to 20 to use
+  patched Hono dependencies.
+- **Build and test gates**: Clean stale build output, run formatting as a
+  non-mutating check, and count live end-to-end assertion failures instead of
+  reporting false passes.
+- **Release authentication**: Replaced long-lived npm and Codecov tokens with
+  short-lived GitHub OIDC credentials; npm trusted publishing now emits
+  provenance automatically.
+- **Repository access**: Changed the OOREP submodule URL from SSH to HTTPS so
+  anonymous clones can initialize it.
+
+### Fixed
+
+- **Live repertory search**: Support the current grouped OOREP response shape
+  while retaining compatibility with legacy flat results.
+- **Metadata validation**: Omit unavailable repertory and materia medica
+  author/language fields instead of returning invalid `null` values.
+- **CodeQL findings**: Removed unused bindings and scoped SARIF upload
+  permissions to the analysis job.
+- **Package surface**: Removed a duplicate interface barrel and corrected the
+  public SDK interface/export checks.
+
+### Security
+
+- Updated direct and transitive dependencies to remove all 18 reported npm
+  audit findings, including two critical findings.
+- Pinned third-party GitHub Actions to immutable commit SHAs and disabled
+  persisted checkout credentials.
+- Made CodeQL, Codecov, and OpenSSF failures visible instead of allowing silent
+  success.
+
+### Dependencies
+
+- **Core**: `@modelcontextprotocol/sdk` 1.25.1 → 1.30.0, `zod` 4.2.1 →
+  4.3.5.
+- **Toolchain**: TypeScript 5.8 → 6.0.3, ESLint 9 → 10, Node.js types 25 →
+  26, Vitest 4.0 → 4.1, and compatible TypeScript-ESLint, Prettier, and
+  transitive security updates.
+
 ## [1.2.1] - 2025-12-25
 
 ### Changed
@@ -402,6 +455,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - For full functionality, users should run a local OOREP instance or configure authentication
 - Public metadata endpoints work without authentication (remedies list, repertories list, materia medicas list)
 
+[1.2.2]: https://github.com/Dhi13man/oorep-mcp/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/Dhi13man/oorep-mcp/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Dhi13man/oorep-mcp/compare/v1.1.3...v1.2.0
 [1.1.3]: https://github.com/Dhi13man/oorep-mcp/compare/v1.1.2...v1.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Build and test gates**: Clean stale build output, run formatting as a
   non-mutating check, and count live end-to-end assertion failures instead of
   reporting false passes.
-- **Release authentication**: Replaced long-lived npm and Codecov tokens with
-  short-lived GitHub OIDC credentials; npm trusted publishing now emits
-  provenance automatically.
+- **Release authentication**: Replaced long-lived npm tokens with short-lived
+  GitHub OIDC credentials; npm trusted publishing now emits provenance
+  automatically.
 - **Repository access**: Changed the OOREP submodule URL from SSH to HTTPS so
   anonymous clones can initialize it.
 
@@ -47,8 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   audit findings, including two critical findings.
 - Pinned third-party GitHub Actions to immutable commit SHAs and disabled
   persisted checkout credentials.
-- Made CodeQL, Codecov, and OpenSSF failures visible instead of allowing silent
-  success.
+- Made CodeQL and OpenSSF failures visible, and removed the inactive Codecov
+  upload path while retaining enforced coverage thresholds in CI.
 
 ### Dependencies
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,13 @@
+cff-version: 1.2.0
+message: If you use oorep-mcp, please cite this software.
+type: software
+title: oorep-mcp
+abstract: MCP server and TypeScript client SDK for OOREP homeopathic repertory and materia medica reference data.
+authors:
+  - family-names: Seal
+    given-names: Dhiman
+repository-code: https://github.com/Dhi13man/oorep-mcp
+url: https://www.npmjs.com/package/oorep-mcp
+license: MIT
+version: 1.2.2
+date-released: 2026-08-03

--- a/README.md
+++ b/README.md
@@ -6,15 +6,14 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Dhi13man/oorep-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/Dhi13man/oorep-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-[!["Buy Me A Coffee"](https://img.buymeacoffee.com/button-api/?text=Buy%20me%20an%20Ego%20boost&emoji=%F0%9F%98%B3&slug=dhi13man&button_colour=FF5F5F&font_colour=ffffff&font_family=Lato&outline_colour=000000&coffee_colour=FFDD00)](https://www.buymeacoffee.com/dhi13man)
-
-**Model Context Protocol server (and Client SDK) providing AI assistants access to OOREP - a comprehensive homeopathic repertory and materia medica database.**
+An MCP server and TypeScript client SDK that gives AI assistants access to
+OOREP's homeopathic repertory and materia medica reference data.
 
 ## TL;DR
 
 ```bash
 # Install and run (no setup required)
-npx oorep-mcp
+npx -y oorep-mcp
 ```
 
 ```typescript
@@ -83,6 +82,8 @@ This MCP server enables AI assistants to query this data programmatically.
 
 ## Quick Start
 
+Requires [Node.js 20 or newer](https://nodejs.org/) with npm/npx.
+
 ### 1. Add to Claude Desktop
 
 **macOS:** Edit `~/Library/Application Support/Claude/claude_desktop_config.json`
@@ -120,7 +121,7 @@ Quit completely (Cmd+Q / Alt+F4), then reopen.
 No installation required:
 
 ```bash
-npx oorep-mcp
+npx -y oorep-mcp
 ```
 
 ### npm Global
@@ -937,3 +938,4 @@ MIT License - see [LICENSE](LICENSE) file for details.
 - **MCP Documentation**: <https://modelcontextprotocol.io>
 - **Issue Tracker**: <https://github.com/Dhi13man/oorep-mcp/issues>
 - **npm Package**: <https://www.npmjs.com/package/oorep-mcp>
+- **Support Development**: <https://www.buymeacoffee.com/dhi13man>

--- a/docs/REPERTORY_STRUCTURES.md
+++ b/docs/REPERTORY_STRUCTURES.md
@@ -2,6 +2,17 @@
 
 Comprehensive analysis of homeopathic repertory structures based on parsed data from Kent, Murphy, Synthesis, and Boenninghausen (BG3.100). This document serves as a reference for building effective AI prompts and search guides that work across all repertories.
 
+## Data Provenance
+
+This is a historical analysis published with oorep-mcp v1.2.1 on 2025-12-25.
+The referenced OOREP source snapshot is submodule commit
+[`104f51f8660d5a42418a579a0963e77b291a80ff`](https://github.com/nondeterministic/oorep/tree/104f51f8660d5a42418a579a0963e77b291a80ff).
+
+The original extraction script and raw count output were not retained, so the
+aggregate counts in this document cannot be independently reproduced from this
+repository alone. Treat them as snapshot evidence rather than current OOREP
+totals; use the live MCP discovery and search tools for current data.
+
 ## Executive Summary
 
 | Repertory | Chapters | Total Symptoms | Root Rubrics | Unique Characteristics |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oorep-mcp",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oorep-mcp",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oorep-mcp",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "MCP server for OOREP homeopathic repertory and materia medica - enables AI assistants to search symptoms, remedies, and homeopathic reference materials",
   "mcpName": "io.github.dhi13man/oorep-mcp",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -1,13 +1,20 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.dhi13man/oorep-mcp",
-  "description": "MCP server for OOREP homeopathic repertory and materia medica - enables AI assistants to search symptoms, remedies, and homeopathic reference materials",
-  "version": "0.0.7",
+  "description": "MCP server and TypeScript SDK for OOREP homeopathic repertory and materia medica reference data.",
+  "repository": {
+    "url": "https://github.com/Dhi13man/oorep-mcp",
+    "source": "github"
+  },
+  "version": "1.2.2",
   "packages": [
     {
-      "registry_type": "npm",
+      "registryType": "npm",
       "identifier": "oorep-mcp",
-      "version": "0.0.7"
+      "version": "1.2.2",
+      "transport": {
+        "type": "stdio"
+      }
     }
   ]
 }

--- a/src/lib/data-formatter.ts
+++ b/src/lib/data-formatter.ts
@@ -10,22 +10,38 @@ import type {
   MateriaMedicaResult,
 } from '../utils/schemas.js';
 
+type RawRepertoryRubric = {
+  rubric: {
+    fullPath?: string | null;
+    textt?: string | null;
+  };
+  weightedRemedies: Array<{
+    remedy: {
+      nameAbbrev: string;
+      nameLong: string;
+    };
+    weight: number;
+  }>;
+};
+
+type RawFlatRepertoryRubric = RawRepertoryRubric & {
+  repertoryAbbrev: string;
+};
+
+type RawGroupedRepertoryRubric = RawRepertoryRubric & {
+  rubric: RawRepertoryRubric['rubric'] & {
+    abbrev: string;
+  };
+};
+
 type RawRepertoryResult = {
   totalNumberOfResults: number;
-  results: Array<{
-    rubric: {
-      fullPath?: string;
-      textt?: string | null;
-    };
-    repertoryAbbrev: string;
-    weightedRemedies: Array<{
-      remedy: {
-        nameAbbrev: string;
-        nameLong: string;
-      };
-      weight: number;
-    }>;
-  }>;
+  results: Array<
+    | RawFlatRepertoryRubric
+    | {
+        subRubrics: RawGroupedRepertoryRubric[];
+      }
+  >;
 };
 
 type RawMateriaMedicaResult = {
@@ -60,12 +76,15 @@ export function formatRepertoryResults(
     };
   }
 
+  const rawRubrics = apiResponse.results.flatMap<
+    RawFlatRepertoryRubric | RawGroupedRepertoryRubric
+  >((result) => ('subRubrics' in result ? result.subRubrics : [result]));
   const limit =
-    options.maxResults && options.maxResults > 0 ? options.maxResults : apiResponse.results.length;
+    options.maxResults && options.maxResults > 0 ? options.maxResults : rawRubrics.length;
 
-  const rubrics: Rubric[] = apiResponse.results.slice(0, limit).map((result) => ({
+  const rubrics: Rubric[] = rawRubrics.slice(0, limit).map((result) => ({
     rubric: result.rubric.fullPath || result.rubric.textt || 'Untitled rubric',
-    repertory: result.repertoryAbbrev,
+    repertory: 'repertoryAbbrev' in result ? result.repertoryAbbrev : result.rubric.abbrev,
     remedies: result.weightedRemedies.map((remedy) => ({
       name: remedy.remedy.nameLong || remedy.remedy.nameAbbrev,
       abbreviation: remedy.remedy.nameAbbrev,

--- a/src/lib/data-formatter.unit.test.ts
+++ b/src/lib/data-formatter.unit.test.ts
@@ -46,6 +46,58 @@ describe('formatRepertoryResults', () => {
     expect(result.rubrics[0].remedies[0].name).toBe('Aconitum napellus');
   });
 
+  it('formatRepertoryResults when response groups subrubrics then flattens them', () => {
+    // Arrange
+    const mockApiResponse = {
+      totalNumberOfResults: 202,
+      results: [
+        {
+          id: -1,
+          cazeId: -1,
+          rubricWeight: 1,
+          rubricLabel: null,
+          subRubrics: [
+            {
+              rubric: {
+                abbrev: 'publicum',
+                id: 69877,
+                fullPath: 'Abdomen, headache with, agg.',
+              },
+              weightedRemedies: [
+                {
+                  remedy: { nameAbbrev: 'Bell.', nameLong: 'Belladonna' },
+                  weight: 3,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    // Act
+    const result = formatRepertoryResults(mockApiResponse, { includeRemedyStats: false });
+
+    // Assert
+    expect(result).toEqual({
+      totalResults: 202,
+      rubrics: [
+        {
+          rubric: 'Abdomen, headache with, agg.',
+          repertory: 'publicum',
+          remedies: [
+            {
+              name: 'Belladonna',
+              abbreviation: 'Bell.',
+              weight: 3,
+            },
+          ],
+        },
+      ],
+      remedyStats: undefined,
+    });
+  });
+
   it('formatRepertoryResults when rubric has textt but no fullPath then uses textt', () => {
     const mockApiResponse = {
       totalNumberOfResults: 1,

--- a/src/lib/oorep-client.ts
+++ b/src/lib/oorep-client.ts
@@ -41,12 +41,16 @@ type RawRepertoryCase = {
   weightedRemedies: RawWeightedRemedy[];
 };
 
+type RawGroupedRepertoryCase = {
+  subRubrics: Array<Omit<RawRepertoryCase, 'repertoryAbbrev'>>;
+};
+
 type RawRepertoryPayload = {
   totalNumberOfRepertoryRubrics: number;
   totalNumberOfResults: number;
   totalNumberOfPages: number;
   currPage: number;
-  results: RawRepertoryCase[];
+  results: Array<RawRepertoryCase | RawGroupedRepertoryCase>;
 };
 
 type RawRepertoryResponse = [
@@ -460,9 +464,9 @@ export class OOREPHttpClient {
         info: {
           abbrev: string;
           title: string;
-          authorLastName?: string;
-          authorFirstName?: string;
-          language?: string;
+          authorLastName?: string | null;
+          authorFirstName?: string | null;
+          language?: string | null;
         };
       }>
     >('/api/available_rems_and_reps');
@@ -473,8 +477,8 @@ export class OOREPHttpClient {
       author:
         item.info.authorLastName && item.info.authorFirstName
           ? `${item.info.authorFirstName} ${item.info.authorLastName}`
-          : item.info.authorLastName || item.info.authorFirstName,
-      language: item.info.language,
+          : item.info.authorLastName || item.info.authorFirstName || undefined,
+      language: item.info.language ?? undefined,
     }));
   }
 
@@ -491,9 +495,9 @@ export class OOREPHttpClient {
           abbrev: string;
           displaytitle?: string;
           fulltitle?: string;
-          authorlastname?: string;
-          authorfirstname?: string;
-          lang?: string;
+          authorlastname?: string | null;
+          authorfirstname?: string | null;
+          lang?: string | null;
         };
       }>
     >('/api/available_rems_and_mms');
@@ -504,8 +508,8 @@ export class OOREPHttpClient {
       author:
         item.mminfo.authorlastname && item.mminfo.authorfirstname
           ? `${item.mminfo.authorfirstname} ${item.mminfo.authorlastname}`
-          : item.mminfo.authorlastname || item.mminfo.authorfirstname,
-      language: item.mminfo.lang,
+          : item.mminfo.authorlastname || item.mminfo.authorfirstname || undefined,
+      language: item.mminfo.lang ?? undefined,
     }));
   }
 }

--- a/src/lib/oorep-client.unit.test.ts
+++ b/src/lib/oorep-client.unit.test.ts
@@ -885,6 +885,43 @@ describe('OOREPHttpClient', () => {
       expect(result[0].author).toBe('James Kent');
     });
 
+    it('getAvailableRepertories when upstream metadata is null then normalizes it to undefined', async () => {
+      // Arrange
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: () =>
+          Promise.resolve(
+            JSON.stringify([
+              {
+                info: {
+                  abbrev: 'dorcsi-de',
+                  title: 'Dorcsi Repertory',
+                  authorFirstName: null,
+                  authorLastName: null,
+                  language: null,
+                },
+              },
+            ])
+          ),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // Act
+      const result = await mockClient.getAvailableRepertories();
+
+      // Assert
+      expect(result).toEqual([
+        {
+          abbreviation: 'dorcsi-de',
+          title: 'Dorcsi Repertory',
+          author: undefined,
+          language: undefined,
+        },
+      ]);
+    });
+
     it('getAvailableRepertories when only lastName then uses it', async () => {
       const mockApiResponse = [
         {
@@ -998,6 +1035,44 @@ describe('OOREPHttpClient', () => {
       expect(result[0].abbreviation).toBe('boericke');
       expect(result[0].title).toBe('Boericke MM');
       expect(result[0].author).toBe('William Boericke');
+    });
+
+    it('getAvailableMateriaMedicas when upstream metadata is null then normalizes it to undefined', async () => {
+      // Arrange
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: () =>
+          Promise.resolve(
+            JSON.stringify([
+              {
+                mminfo: {
+                  id: 1,
+                  abbrev: 'heringc',
+                  displaytitle: 'Hering Guiding Symptoms',
+                  authorfirstname: null,
+                  authorlastname: null,
+                  lang: null,
+                },
+              },
+            ])
+          ),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // Act
+      const result = await mockClient.getAvailableMateriaMedicas();
+
+      // Assert
+      expect(result).toEqual([
+        {
+          abbreviation: 'heringc',
+          title: 'Hering Guiding Symptoms',
+          author: undefined,
+          language: undefined,
+        },
+      ]);
     });
 
     it('getAvailableMateriaMedicas when no displaytitle then uses fulltitle', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/test-helpers.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,14 +6,19 @@ export default defineConfig({
     environment: 'node',
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
-      exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/__tests__/**'],
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.test.ts',
+        '**/__tests__/**'
+      ],
       thresholds: {
         lines: 85,
         functions: 85,
         branches: 80,
-        statements: 85,
-      },
-    },
-  },
+        statements: 85
+      }
+    }
+  }
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,19 +6,14 @@ export default defineConfig({
     environment: 'node',
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-      exclude: [
-        'node_modules/',
-        'dist/',
-        '**/*.test.ts',
-        '**/__tests__/**'
-      ],
+      reporter: ['text', 'json', 'html', 'lcov'],
+      exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/__tests__/**'],
       thresholds: {
         lines: 85,
         functions: 85,
         branches: 80,
-        statements: 85
-      }
-    }
-  }
+        statements: 85,
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Why

The current OOREP API groups repertory matches under `subRubrics` and can return nullable catalogue metadata. The v1.2.1 client assumed flat matches and non-null strings, so live searches could crash or fail schema validation. The release path also needed a secure, reproducible npm and official MCP Registry publication lane before shipping the accumulated maintenance work since v1.2.1.

## What Changed

- Flatten current grouped repertory results before limiting them while preserving the legacy flat response contract.
- Normalize nullable repertory and materia medica metadata to omitted optional fields.
- Publish only a reviewed tag at the exact protected `master` commit through the protected `release` environment.
- Replace long-lived npm tokens with scoped OIDC, verify npm integrity/provenance, and make npm/MCP reruns fail closed on mismatched artifacts or metadata.
- Remove the inactive Codecov upload path while retaining enforced Node 22 coverage thresholds.
- Pin a trusted-publishing-capable npm CLI and the MCP publisher, and keep test-only helpers out of the package.
- Prepare v1.2.2 metadata and changelog, add citation/funding metadata, improve README discovery, document data provenance, and make the OOREP submodule anonymously cloneable.

## Design and Tradeoffs

- Existing flat OOREP payloads remain supported; no public SDK or MCP tool contract is intentionally broken.
- The official MCP Registry's recommended GitHub OIDC flow has an owner-wide namespace trust boundary. This repository mitigates it with a required-reviewer release environment, exact-master verification, immutable tooling, and sole repository write ownership.
- No retries or timeout inflation were added to hide OOREP availability failures.

## Verification

- Regression tests were written first and failed for grouped results plus both nullable metadata paths before the production fix; all three passed afterward.
- `npm run prepublishOnly`: 37 files / 1,105 tests passed, with typecheck, formatting, build, and ESLint green.
- Coverage: 94.94% statements, 93.78% branches, 94.94% functions, 95.08% lines.
- `npm audit --audit-level=low`: 0 vulnerabilities.
- npm 10 and npm 11 clean installs passed; packed package passed fresh-consumer imports for the root and all five adapter exports.
- actionlint 1.7.12 + ShellCheck 0.11.0, MCP publisher schema validation, CFF 1.2.0 validation, Markdownlint, Publint, Are The Types Wrong, Gitleaks, and `git diff --check` passed.
- The corrected npm workflow selects the first-publish branch for absent 1.2.2 and the existing-version branch for 1.2.1; npm signature/attestation verification was exercised independently.
- Live OOREP verification confirmed the grouped search fix (`headache`: 202 results / 5 returned rubrics; Kent: 3 rubrics). The provider later stopped accepting TCP 443 connections; the latest full rerun passed 31/39 local MCP assertions and failed eight provider-backed assertions with `UND_ERR_CONNECT_TIMEOUT`.
- Fresh GitHub CI exposed that Codecov had never been activated. The final design removes that dormant external dependency and still fails CI whenever Node 22 coverage drops below the repository thresholds.
- Independent code and security reviews found no remaining actionable findings. The npm trusted-publisher binding is the final external release prerequisite and will be verified before the GitHub Release is published.

## Checklist

- [x] The change is focused and preserves public compatibility, or a breaking change is clearly identified.
- [x] Tests cover changed behavior and relevant failure paths.
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check`, and `npm test` pass.
- [x] Documentation and `CHANGELOG.md` are updated when user-facing behavior changes.
- [x] No secrets, credentials, or personal information are included.