### PR TITLE
fix(release): publish canonical MCP namespace

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,12 +53,16 @@ jobs:
 
       - name: Verify version matches tag
         env:
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
+          PACKAGE_MCP_NAME=$(node -p "require('./package.json').mcpName")
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          TAG_VERSION=${RELEASE_TAG#v}
+          SERVER_NAME=$(node -p "require('./server.json').name")
           SERVER_VERSION=$(node -p "require('./server.json').version")
           SERVER_PACKAGE_VERSION=$(node -p "require('./server.json').packages[0].version")
+          EXPECTED_SERVER_NAME="io.github.${GITHUB_REPOSITORY_OWNER}/oorep-mcp"
+          TAG_VERSION=${RELEASE_TAG#v}
 
           if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
             echo "Version mismatch: package.json=$PACKAGE_VERSION, tag=$TAG_VERSION"
@@ -66,6 +70,10 @@ jobs:
           fi
           if [ "$SERVER_VERSION" != "$PACKAGE_VERSION" ] || [ "$SERVER_PACKAGE_VERSION" != "$PACKAGE_VERSION" ]; then
             echo "Version mismatch: package.json=$PACKAGE_VERSION, server.json=$SERVER_VERSION, server package=$SERVER_PACKAGE_VERSION"
+            exit 1
+          fi
+          if [ "$PACKAGE_MCP_NAME" != "$EXPECTED_SERVER_NAME" ] || [ "$SERVER_NAME" != "$EXPECTED_SERVER_NAME" ]; then
+            echo "MCP namespace mismatch: expected=$EXPECTED_SERVER_NAME, package.json=$PACKAGE_MCP_NAME, server.json=$SERVER_NAME"
             exit 1
           fi
           echo "Version matches: $PACKAGE_VERSION"
@@ -214,12 +222,14 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          SERVER_NAME=$(node -p "require('./server.json').name")
           {
             echo "### Release published"
             echo ""
             echo "- **Package**: oorep-mcp"
-            echo "- **Version**: $(node -p 'require(\"./package.json\").version')"
+            echo "- **Version**: $PACKAGE_VERSION"
             echo "- **Tag**: $RELEASE_TAG"
             echo "- **npm provenance**: enabled by trusted publishing"
-            echo "- **MCP Registry**: io.github.dhi13man/oorep-mcp"
+            echo "- **MCP Registry**: $SERVER_NAME"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] - 2026-08-03
+
+### Fixed
+
+- **MCP Registry namespace**: Corrected the case-sensitive GitHub OIDC
+  namespace to `io.github.Dhi13man/oorep-mcp`, enabling publication to the
+  official MCP Registry.
+
+### Security
+
+- **Release validation**: Reject MCP namespace drift between the canonical
+  GitHub repository owner, `package.json`, and `server.json` before publishing.
+
 ## [1.2.2] - 2026-08-03
 
 ### Added
@@ -455,6 +468,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - For full functionality, users should run a local OOREP instance or configure authentication
 - Public metadata endpoints work without authentication (remedies list, repertories list, materia medicas list)
 
+[1.2.3]: https://github.com/Dhi13man/oorep-mcp/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/Dhi13man/oorep-mcp/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/Dhi13man/oorep-mcp/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Dhi13man/oorep-mcp/compare/v1.1.3...v1.2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,5 +9,5 @@ authors:
 repository-code: https://github.com/Dhi13man/oorep-mcp
 url: https://www.npmjs.com/package/oorep-mcp
 license: MIT
-version: 1.2.2
+version: 1.2.3
 date-released: 2026-08-03

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oorep-mcp",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oorep-mcp",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "oorep-mcp",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "MCP server for OOREP homeopathic repertory and materia medica - enables AI assistants to search symptoms, remedies, and homeopathic reference materials",
-  "mcpName": "io.github.dhi13man/oorep-mcp",
+  "mcpName": "io.github.Dhi13man/oorep-mcp",
   "type": "module",
   "main": "dist/sdk/index.js",
   "types": "dist/sdk/index.d.ts",

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.dhi13man/oorep-mcp",
+  "name": "io.github.Dhi13man/oorep-mcp",
   "description": "MCP server and TypeScript SDK for OOREP homeopathic repertory and materia medica reference data.",
   "repository": {
     "url": "https://github.com/Dhi13man/oorep-mcp",
     "source": "github"
   },
-  "version": "1.2.2",
+  "version": "1.2.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "oorep-mcp",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Why

The v1.2.2 npm release and provenance verification succeeded, but the official MCP Registry rejected publication because its case-sensitive GitHub OIDC namespace grants `io.github.Dhi13man/*` while the published manifests requested `io.github.dhi13man/oorep-mcp`.

Because npm releases are immutable and the Registry requires `package.json#mcpName` to exactly match `server.json#name`, this needs a v1.2.3 patch rather than rewriting v1.2.2.

## What

- use the canonical `io.github.Dhi13man/oorep-mcp` namespace in npm and MCP metadata
- bump all release metadata to v1.2.3
- preserve the published v1.2.2 changelog and add focused v1.2.3 notes
- reject namespace drift before any package publication
- derive the publication summary from validated manifests

## Verification

- regression oracle failed against v1.2.2 lowercase metadata and passes against v1.2.3
- `npm run prepublishOnly`: 37 files, 1,105 tests passed
- `npm audit --audit-level=low`: 0 vulnerabilities
- official `mcp-publisher v1.8.0 validate`: valid
- actionlint 1.7.12 + ShellCheck 0.11.0: passed
- exact Bash publication-summary expressions: passed
- `npm pack --dry-run --json`: 167 intended files
- `git diff --check`: passed

No runtime implementation or dependency changes are included.